### PR TITLE
refactor(starr): streaming service cleanup

### DIFF
--- a/includes/radarr-cfs.yml
+++ b/includes/radarr-cfs.yml
@@ -48,7 +48,7 @@ custom_formats:
       - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
       - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
       - f537cf427b64c38c8e36298f657e4828 # Scene
-      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
@@ -103,6 +103,7 @@ custom_formats:
 
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - df13ed57843877b21ad969184ab6888f # ATV
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
       - 84272245b2988854bfb76a16e60baea5 # DSNP
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
@@ -113,6 +114,7 @@ custom_formats:
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - 44c2b54d7c81c1a442a8b2cabeaef54f # ROKU
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
       - name: Golden Popcorn

--- a/includes/radarr4k-cfs.yml
+++ b/includes/radarr4k-cfs.yml
@@ -23,7 +23,7 @@ custom_formats:
       - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
       - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
       - f700d29429c023a5734505e77daeaea7 # DV (Disk)
-      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
       # Movie Versions
       - 0f12c086e289cf966fa5948eac571f44 # Hybrid
@@ -95,6 +95,7 @@ custom_formats:
 
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - df13ed57843877b21ad969184ab6888f # ATV
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
       - 84272245b2988854bfb76a16e60baea5 # DSNP
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
@@ -105,6 +106,7 @@ custom_formats:
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - 44c2b54d7c81c1a442a8b2cabeaef54f # ROKU
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
       - name: Remux/IMAX

--- a/includes/radarrgerman-cfs.yml
+++ b/includes/radarrgerman-cfs.yml
@@ -53,7 +53,7 @@ custom_formats:
       - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
       - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
       - f537cf427b64c38c8e36298f657e4828 # Scene
-      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
@@ -92,6 +92,7 @@ custom_formats:
 
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - df13ed57843877b21ad969184ab6888f # ATV
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
       - 84272245b2988854bfb76a16e60baea5 # DSNP
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
@@ -102,6 +103,7 @@ custom_formats:
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - 44c2b54d7c81c1a442a8b2cabeaef54f # ROKU
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
       - name: WEBDL

--- a/includes/sonarr-cfs.yml
+++ b/includes/sonarr-cfs.yml
@@ -33,13 +33,15 @@ custom_formats:
       - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
       - 06d66ab109d4d2eddb2794d21526d140 # Retags
       - 1b3994c551cbb92a2c781af061f4ab44 # Scene
-      - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+      - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
       # Streaming Services
       - d660701077794679fd59e8bdf4ce3a29 # AMZN
+      - d9e511921c8cedc7282e291b0209cdc5 # ATV
       - f67c9ca88f463a48346062e8ad07713f # ATVP
       - 77a7b25585c18af08f60b1547bb9b4fb # CC
       - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
+      - dc5f2bb0e0262155b5fedd0f6c5d2b55 # DSCP
       - 89358767a60cc28783cdc3d0be9388a4 # DSNP
       - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
       - a880d6abc21e7c16884f3ae393f84179 # HMAX
@@ -49,8 +51,13 @@ custom_formats:
       - d34870697c9db575f17700212167be23 # NF
       - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
       - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
+      - da393fd4e2c0cce7c9dc2669c43e0593 # ROKU
       - ae58039e1319178e6be73caab5c42166 # SHO
       - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
+      - 9623c5c9cac8e939c1b9aedd32f640bf # SYFY
+
+      # Steaming Service Modifications
+      - 218e93e5702f44a68ad9e3c6ba87d2f0 # HD Streaming Boost
 
       # Custom Repo CFs
       - 7b0828be9af60eda1bac5569f2ebaf39 # FraMeSToR

--- a/includes/sonarr4k-cfs.yml
+++ b/includes/sonarr4k-cfs.yml
@@ -5,7 +5,7 @@ custom_formats:
       - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
       - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
       - ef4963043b0987f8485bc9106f16db38 # DV (Disk)
-      - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+      - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
       # HQ Release Groups
       - 9965a052eb87b0d10313b1cea89eb451 # Remux Tier 01
@@ -43,9 +43,11 @@ custom_formats:
 
       # Streaming Services
       - d660701077794679fd59e8bdf4ce3a29 # AMZN
+      - d9e511921c8cedc7282e291b0209cdc5 # ATV
       - f67c9ca88f463a48346062e8ad07713f # ATVP
       - 77a7b25585c18af08f60b1547bb9b4fb # CC
       - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
+      - dc5f2bb0e0262155b5fedd0f6c5d2b55 # DSCP
       - 89358767a60cc28783cdc3d0be9388a4 # DSNP
       - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
       - a880d6abc21e7c16884f3ae393f84179 # HMAX
@@ -55,12 +57,14 @@ custom_formats:
       - d34870697c9db575f17700212167be23 # NF
       - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
       - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
+      - da393fd4e2c0cce7c9dc2669c43e0593 # ROKU
       - ae58039e1319178e6be73caab5c42166 # SHO
       - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
+      - 9623c5c9cac8e939c1b9aedd32f640bf # SYFY
 
       # Steaming Service Modifications
       - 43b3cf48cb385cd3eac608ee6bca7f09 # UHD Streaming Boost
-      - d2d299244a92b8a52d4921ce3897a256 # UHD Streaming Cut
+      - 218e93e5702f44a68ad9e3c6ba87d2f0 # HD Streaming Boost
 
       # Custom Repo CFs
       - 7b0828be9af60eda1bac5569f2ebaf39 # FraMeSToR

--- a/includes/sonarrgerman-cfs.yml
+++ b/includes/sonarrgerman-cfs.yml
@@ -49,10 +49,11 @@ custom_formats:
       - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
       - 06d66ab109d4d2eddb2794d21526d140 # Retags
       - 1b3994c551cbb92a2c781af061f4ab44 # Scene
-      - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+      - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
       # Streaming Services
       - d660701077794679fd59e8bdf4ce3a29 # AMZN
+      - d9e511921c8cedc7282e291b0209cdc5 # ATV
       - f67c9ca88f463a48346062e8ad07713f # ATVP
       - 77a7b25585c18af08f60b1547bb9b4fb # CC
       - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
@@ -66,9 +67,13 @@ custom_formats:
       - d34870697c9db575f17700212167be23 # NF
       - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
       - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
+      - da393fd4e2c0cce7c9dc2669c43e0593 # ROKU
       - ae58039e1319178e6be73caab5c42166 # SHO
       - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
       - 9623c5c9cac8e939c1b9aedd32f640bf # SYFY
+
+      # Steaming Service Modifications
+      - 218e93e5702f44a68ad9e3c6ba87d2f0 # HD Streaming Boost
     assign_scores_to:
       - name: WEBDL
 


### PR DESCRIPTION
Add new streaming services and `HD Streaming Boost` and update naming of `DV (w/o HDR fallback)`.